### PR TITLE
Fix VideoTexture creation in Resources

### DIFF
--- a/Experience/Utils/Resources.js
+++ b/Experience/Utils/Resources.js
@@ -46,7 +46,7 @@ export default class Resources extends EventEmitter{
                 this.video[asset.name].loop = true;
                 this.video[asset.name].play();
 
-                this.videoTexture[asset.name] = new THREE.videoTexture(
+                this.videoTexture[asset.name] = new THREE.VideoTexture(
                     this.video[asset.name]
                 );
                 this.videoTexture[asset.name].flipY = true;


### PR DESCRIPTION
## Summary
- fix new THREE.VideoTexture creation in resources loader

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68404b49a5ec83219a76b6d25be6ae38