### PR TITLE
Fix skull model load race

### DIFF
--- a/Experience/World/World.js
+++ b/Experience/World/World.js
@@ -15,11 +15,17 @@ export default class World{
 
         this.AllowUpdate = false;
 
-        this.resources.on("ready", () =>{
+        const onResourcesReady = () => {
             this.Enviroment = new Enviroment();
             this.room = new Room();
             this.AllowUpdate = true;
-        });
+        };
+
+        if (this.resources.loaded === this.resources.queue) {
+            onResourcesReady();
+        } else {
+            this.resources.on("ready", onResourcesReady);
+        }
     }
 
     Resize(){


### PR DESCRIPTION
## Summary
- ensure the world constructs the skull if resources were already loaded
- remove inline comments from the handler logic

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840513be06083218ed2e442bcaf00bf